### PR TITLE
UES-273 use rc version of the datadog agent image

### DIFF
--- a/datadog/definition.json
+++ b/datadog/definition.json
@@ -2,7 +2,7 @@
   {
     "cpu": 10,
     "essential": true,
-    "image": "datadog/agent:latest",
+    "image": "datadog/agent:6.3.0-rc.1",
     "memory": 256,
     "name": "${datadog_name}",
     "mountPoints": [


### PR DESCRIPTION
Because of https://github.com/DataDog/datadog-agent/commit/76e0286b44934972c7b3571e5c0181103b4f8f76