### PR TITLE
way of adding rules to existing groups instead of new groups per service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,3 +49,13 @@ resource "aws_launch_configuration" "lc" {
   // combine alb_instance_sgs defined SGs and the default ECS instance SG for SSH access
   security_groups = ["${concat(list(aws_security_group.instance_default_sg.id), var.alb_instance_sgs)}"]
 }
+
+resource "aws_security_group_rule" "allow_service" {
+  count                    = "${length(var.allow_to_sgs)}"
+  type                     = "ingress"
+  from_port                = "${element( split(",", element( var.allow_to_sgs, count.index ) ), 1 )}"
+  to_port                  = "${element( split(",", element( var.allow_to_sgs, count.index ) ), 1 )}"
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.instance_default_sg.id}"
+  security_group_id        = "${element( split(",", element( var.allow_to_sgs, count.index ) ), 0 )}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,14 @@ variable "availability_zones" {
 
 variable "alb_instance_sgs" {
   type = "list"
+  default =[]
 }
+
+variable "allow_to_sgs" {
+  type = "list"
+  default =[]
+}
+
 
 variable "instance_ssh_cidr_blocks" {
   type    = "list"


### PR DESCRIPTION
additional functionality which adds a security group rule for a port to the given security group for the ECS cluster