### PR TITLE
Remove redis from ECS instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ module "ecs" {
   datadog_api_key = var.datadog_api_key
 
   vpc_id = data.terraform_remote_state.vpc.vpc_id
-  source = "github.com/ryte/INF-tf-ecs?ref=v0.2.0"
+  source = "github.com/ryte/INF-tf-ecs?ref=v0.2.1"
 }
 ```
 
@@ -211,7 +211,9 @@ module "ecs" {
 
 ## Changelog
 
+- 0.2.1 - Remove redis-cli from ECS hosts
 - 0.2.0 - Upgrade to terraform 0.12.x
+- 0.1.5 - Remove redis-cli from ECS hosts (backport)
 - 0.1.4 - Extend root block device
 - 0.1.3 - Fix Datadog-agent writing inside container
 - 0.1.2 - Enable Dogstatsd non_local_traffic

--- a/userdata/cloudinit.sh
+++ b/userdata/cloudinit.sh
@@ -1,10 +1,5 @@
 #!/bin/bash +ex
 
-cd /tmp
-sudo yum install -y gcc
-wget http://download.redis.io/redis-stable.tar.gz && tar xvzf redis-stable.tar.gz && cd redis-stable && make && sudo cp src/redis-cli /usr/bin/ && sudo chmod 755 /usr/bin/redis-cli
-
-
 sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 sudo start amazon-ssm-agent
 


### PR DESCRIPTION
The redis-cli installation was copy&paste from a previous version where we kept information about all ECS tasks in a redis