### PR TITLE
Enable Datadog’s Process Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ module "ecs" {
 
 ## Changelog
 
+- 0.2.2 - Datadog enriched live containers view with process list
 - 0.2.1 - Remove redis-cli from ECS hosts
 - 0.2.0 - Upgrade to terraform 0.12.x
 - 0.1.5 - Remove redis-cli from ECS hosts (backport)

--- a/datadog-agent.tf
+++ b/datadog-agent.tf
@@ -109,6 +109,11 @@ resource "aws_ecs_task_definition" "agent_definition" {
     host_path = local.datadog_log_pointer_dir
   }
 
+  volume {
+    name      = "passwd"
+    host_path = "/etc/passwd"
+  }
+
   requires_compatibilities = [
     "EC2",
   ]
@@ -127,4 +132,3 @@ resource "aws_ecs_service" "agent_service" {
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
 }
-

--- a/datadog/definition.json
+++ b/datadog/definition.json
@@ -35,6 +35,11 @@
         "containerPath": "/opt/datadog-agent/run",
         "sourceVolume": "log_pointer",
         "readOnly": false
+      },
+      {
+        "containerPath": "/etc/passwd",
+        "sourceVolume": "passwd",
+        "readOnly": true
       }
     ],
     "environment": [
@@ -68,6 +73,10 @@
       },
       {
         "name": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC",
+        "value": "true"
+      },
+      {
+        "name": "DD_PROCESS_AGENT_ENABLED",
         "value": "true"
       }
     ]


### PR DESCRIPTION
- Following this docs: https://docs.datadoghq.com/infrastructure/process/?tab=docker
I would like to enable this feature to monitor the processes list inside a task