### PR TITLE
Enable AWS ECS metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Description: security group of the cluster
 
 ```hcl
 module "ecs" {
-  source      = "github.com/ryte/INF-tf-ecs?ref=v0.2.5"
+  source      = "github.com/ryte/INF-tf-ecs?ref=v0.2.6"
   tags        = local.common_tags
   environment = var.environment
   squad       = var.squad
@@ -325,6 +325,7 @@ module "ecs" {
 
 ## Changelog
 
+- 0.2.6 - Enable AWS ECS metadata file
 - 0.2.5 - Enable Datadog to collect APM logs
 - 0.2.4 - Removed deprecated `null_data_source`
 - 0.2.3 - Add variable `environment` and `squad` instead of reading from tags

--- a/userdata/cloudinit.sh
+++ b/userdata/cloudinit.sh
@@ -7,6 +7,7 @@ sudo start amazon-ssm-agent
 cat << EOF > /etc/ecs/ecs.config
 ECS_CLUSTER=${cluster_name}
 ECS_RESERVED_MEMORY=64
+ECS_ENABLE_CONTAINER_METADATA=true
 ${ecs_engine_auth_type}
 ${list_of_registries}
 EOF


### PR DESCRIPTION
This enables [AWS ECS metadata file](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)