### PR TITLE
Custom log retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,14 @@ Description: name of the cluster
 
 Description: security group of the cluster
 
+### log\_retention
+
+Description: Log retention in days
+
+Type: `number`
+
+Default: `30`
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ module "ecs" {
 
 ## Changelog
 
+- 0.2.7 - Add custom value for log retention
 - 0.2.6 - Enable AWS ECS metadata file
 - 0.2.5 - Enable Datadog to collect APM logs
 - 0.2.4 - Removed deprecated `null_data_source`

--- a/logs.tf
+++ b/logs.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "log_group" {
   name              = local.name
-  retention_in_days = 30
+  retention_in_days = var.log_retention
   tags              = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,11 @@ variable "ssh_key_name" {
   default     = ""
 }
 
+variable "log_retention" {
+  description = "Log retention in Days"
+  default     = 30
+}
+
 variable "instance_tags" {
   type = list(object({
     key                 = string


### PR DESCRIPTION
This PR adds the option to customize the log retention of ECS Cluster Cloudwatch logs. The Default is the former value so existing code should not unexpected change.